### PR TITLE
Updates to the cheat sheet for the Octane launch

### DIFF
--- a/code/constructors/classic.js
+++ b/code/constructors/classic.js
@@ -3,6 +3,6 @@ import Component from '@ember/component';
 export default Component.extend({
     init() {
         this._super(...arguments)
-        this.set('bestActor', "Milo")
+        this.set('answer', 42)
     }
 });

--- a/code/constructors/octane.js
+++ b/code/constructors/octane.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 
 export default class SomeComponent extends Component {
   constructor() {
-    super();
-    this.bestActor = 'Milo';
+    super(...arguments);
+    this.answer = 42;
   }
 }

--- a/code/ddau/classic-child.handlebars
+++ b/code/ddau/classic-child.handlebars
@@ -1,0 +1,5 @@
+{{!-- child-component.hbs --}}
+
+<button {{action "plusOne"}}>
+  Click Me
+</button>

--- a/code/ddau/classic-child.js
+++ b/code/ddau/classic-child.js
@@ -1,0 +1,12 @@
+// child-component.js
+
+import Component from '@ember/component';
+
+export default Component.extend({
+  actions: {
+    plusOne() {
+      let count = this.get("count");
+      this.set("count", count)
+    }
+  }
+});

--- a/code/ddau/classic-parent.handlebars
+++ b/code/ddau/classic-parent.handlebars
@@ -1,0 +1,3 @@
+{{!-- parent-component.hbs --}}
+{{child-component count=count}}
+Count: {{this.count}}

--- a/code/ddau/classic-parent.js
+++ b/code/ddau/classic-parent.js
@@ -1,0 +1,6 @@
+// parent-component.js
+import Component from '@ember/component';
+
+export default Component.extend({
+  count: 0
+});

--- a/code/ddau/octane-child.handlebars
+++ b/code/ddau/octane-child.handlebars
@@ -1,0 +1,5 @@
+{{!-- child-component.hbs --}}
+
+<button {{on "click" @plusOne}}>
+  Click Me
+</button>

--- a/code/ddau/octane-parent.handlebars
+++ b/code/ddau/octane-parent.handlebars
@@ -1,0 +1,4 @@
+{{!-- parent-component.hbs --}}
+
+<ChildComponent @plusOne={{this.plusOne}} />
+Count: {{this.count}}

--- a/code/ddau/octane-parent.js
+++ b/code/ddau/octane-parent.js
@@ -1,0 +1,13 @@
+// parent-component.js
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class ParentComponent extends Component {
+  @tracked count = 0;
+
+  @action
+  plusOne() {
+    this.count += 1;
+  }
+}

--- a/code/element-id/classic.handlebars
+++ b/code/element-id/classic.handlebars
@@ -1,0 +1,8 @@
+<div class="form-group">
+  <label for="textInput-{{elementId}}">{{inputLabelText}}</label>
+  <input 
+    id="textInput-{{elementId}}"
+    name={{inputName}} 
+    type="text" 
+  />
+</div>

--- a/code/element-id/classic.js
+++ b/code/element-id/classic.js
@@ -1,0 +1,7 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+  didInsertElement() {
+    console.log("Elememt id ", this.elementId)
+  }
+});

--- a/code/element-id/octane.handlebars
+++ b/code/element-id/octane.handlebars
@@ -1,0 +1,8 @@
+<div class="form-group">
+  <label for={{this.inputId}}>{{@inputLabelText}}</label>
+  <input 
+    id={{this.inputId}} 
+    name={{@inputName}} 
+    type="text" 
+  />
+</div>

--- a/code/element-id/octane.js
+++ b/code/element-id/octane.js
@@ -1,0 +1,6 @@
+import Component from '@glimmer/component';
+import { guidFor } from '@ember/object/internals';
+
+export default class InputTextComponent extends Component {
+  inputId = 'textInput-' + guidFor(this); 
+}

--- a/code/file-structure/classic.text
+++ b/code/file-structure/classic.text
@@ -1,0 +1,6 @@
+app/
+  components/
+    my-component.js
+  templates/
+    components/
+      my-component.hbs

--- a/code/file-structure/octane.text
+++ b/code/file-structure/octane.text
@@ -1,0 +1,5 @@
+app/
+  components/
+    my-component.js
+    my-component.hbs
+      

--- a/code/generating-component/classic.shell
+++ b/code/generating-component/classic.shell
@@ -1,0 +1,1 @@
+ember generate component

--- a/code/generating-component/octane.shell
+++ b/code/generating-component/octane.shell
@@ -1,0 +1,8 @@
+# -gc stands for glimmer component
+ember generate component my-component -gc
+
+# -cc stands for classic component
+ember generate component my-component -cc
+
+# See the full set of options with this:
+ember generate component --help

--- a/code/get-and-set/classic.js
+++ b/code/get-and-set/classic.js
@@ -1,0 +1,12 @@
+// child-component.js
+
+import Component from '@ember/component';
+
+export default Component.extend({
+  count: 0,
+  actions: {
+    minusOne() {
+      this.set("count", this.count - 1)
+    }
+  }
+});

--- a/code/get-and-set/octane.js
+++ b/code/get-and-set/octane.js
@@ -1,0 +1,12 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class SomeComponent extends Component {
+  @tracked count = 0;
+
+  @action
+  minusOne() {
+    this.count = this.count - 1
+  }
+}

--- a/code/js-boilerplate/classic.js
+++ b/code/js-boilerplate/classic.js
@@ -3,7 +3,5 @@ import Component from '@ember/component';
 export default Component.extend({
   init() {
     this._super(...arguments);
-
-    // initialize
   },
 });

--- a/code/js-properties/classic.js
+++ b/code/js-properties/classic.js
@@ -1,6 +1,6 @@
 import Component from '@ember/component';
 
 export default Component.extend({
-  fireNation: 'Zuko',
-  airNation: 'Tenzen',
+  min: 0,
+  max: 100,
 });

--- a/code/js-properties/octane.js
+++ b/code/js-properties/octane.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 
 export default class SomeComponent extends Component {
-  fireNation = 'Zuko';
-  airNation = 'Tenzen';
+  min = 0;
+  max = 100;
 }

--- a/code/mixins/classic.js
+++ b/code/mixins/classic.js
@@ -1,0 +1,6 @@
+import Component from '@ember/component';
+import SomeMixin from 'some-addon';
+
+export default Component.extend(SomeMixin, {
+  // ...
+});

--- a/code/model-access/classic.handlebars
+++ b/code/model-access/classic.handlebars
@@ -1,0 +1,1 @@
+First name: {{model.firstName}}

--- a/code/model-access/octane.handlebars
+++ b/code/model-access/octane.handlebars
@@ -1,0 +1,1 @@
+First name: {{@model.firstName}}

--- a/code/template-arguments-default/classic.handlebars
+++ b/code/template-arguments-default/classic.handlebars
@@ -1,4 +1,4 @@
-{{my-component avatar=avatar}}
+{{my-component answer=answer}}
 
 <!-- my-component's template -->
-{{avatar}}
+{{answer}}

--- a/code/template-arguments-default/classic.js
+++ b/code/template-arguments-default/classic.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
 
 export default Component.extend({
-  avatar: 'default',
+  answer: 42,
 });

--- a/code/template-arguments-default/octane.handlebars
+++ b/code/template-arguments-default/octane.handlebars
@@ -1,4 +1,4 @@
-<MyComponent @avatar={{this.avatar}} />
+<MyComponent @answer={{this.answer}} />
 
 <!-- my-component's template -->
-{{this.avatar}}
+{{this.answer}}

--- a/code/template-arguments-default/octane.js
+++ b/code/template-arguments-default/octane.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 
 export default class MyComponent extends Component {
-  get avatar() {
-    return this.args.avatar || 'default';
+  get answer() {
+    return this.args.answer || 42;
   }
 }

--- a/code/template-arguments-named/classic.handlebars
+++ b/code/template-arguments-named/classic.handlebars
@@ -1,1 +1,1 @@
-{{my-component avatar="aang"}}
+{{my-component answer=42}}

--- a/code/template-arguments-named/octane.handlebars
+++ b/code/template-arguments-named/octane.handlebars
@@ -1,1 +1,1 @@
-<MyComponent @avatar="aang" />
+<MyComponent @answer=42 />

--- a/code/template-arguments-named/octane.handlebars
+++ b/code/template-arguments-named/octane.handlebars
@@ -1,1 +1,1 @@
-<MyComponent @answer=42 />
+<MyComponent @answer={{42}} />

--- a/code/template-arguments-this/classic.handlebars
+++ b/code/template-arguments-this/classic.handlebars
@@ -1,1 +1,1 @@
-{{my-component avatar=avatar}}
+{{my-component answer=answer}}

--- a/code/template-arguments-this/octane.handlebars
+++ b/code/template-arguments-this/octane.handlebars
@@ -1,1 +1,1 @@
-<MyComponent @avatar={{this.avatar}} />
+<MyComponent @answer={{this.answer}} />

--- a/code/template-named/classic.handlebars
+++ b/code/template-named/classic.handlebars
@@ -1,1 +1,1 @@
-{{avatar}} is the master of all four elements.
+{{answer}} is the answer.

--- a/code/template-named/octane.handlebars
+++ b/code/template-named/octane.handlebars
@@ -1,1 +1,1 @@
-{{@avatar}} is the master of all four elements.
+{{@answer}} is the answer.

--- a/code/template-this/classic.handlebars
+++ b/code/template-this/classic.handlebars
@@ -1,1 +1,1 @@
-{{bestEpisode}} is my favorite
+{{answer}} is the answer.

--- a/code/template-this/octane.handlebars
+++ b/code/template-this/octane.handlebars
@@ -1,1 +1,1 @@
-{{this.bestEpisode}} is my favorite
+{{this.answer}} is the answer.

--- a/index.html
+++ b/index.html
@@ -22,6 +22,10 @@
           >the GitHub repository</a
         >
       </p>
+      <p>
+        For in-depth information about the upgrade paths and differences introduced in Octane, see
+        <a href="https://octane-guides-preview.emberjs.com/release/upgrading/">The Octane Upgrading Guide</a>.
+      </p>
 
       <h2 id="generating-files"><a href="#generating-files" title="Generating Files" class="permalink">&sect;</a>Generating Files</h2>
 

--- a/index.html
+++ b/index.html
@@ -226,6 +226,25 @@
         </div>
       </section>
 
+      <section aria-labelledby="section-element-id">
+        <h3 id="section-element-id">Make your own elementId</h3>
+        <p>
+          Since components are tagless, there's no elementId, but you can generate your own.
+          This is especially helpful for creating accessible forms.
+        </p>
+        <div class="grid">
+          <div>
+            <h4>Classic</h4>
+            <pre data-src="code/element-id/classic.js"></pre>
+            <pre data-src="code/element-id/classic.handlebars"></pre>
+          </div>
+          <div>
+            <h4>Octane</h4>
+            <pre data-src="code/element-id/octane.handlebars"></pre>
+            <pre data-src="code/element-id/octane.handlebars"></pre>
+          </div>
+        </div>
+      </section>
 
       <h2 id="component-properties"><a href="#component-properties" title="Component Properties" class="permalink">&sect;</a>Component Properties</h2>
 
@@ -354,6 +373,29 @@
             Octane
             <pre data-src="code/template-arguments-default/octane.handlebars"></pre>
             <pre data-src="code/template-arguments-default/octane.js"></pre>
+          </div>
+        </div>
+      </section>
+
+      <section aria-labelledby="section-mixins">
+        <h3 id="section-mixins">Mixins</h3>
+        <p>
+          You cannot use mixins on anything that uses Native Class syntax (such as components that import from @glimmer/component). The replacement strategy depends on your use case. If your app depends on an addon that uses Mixins, it may be best to continue using classic components until an alternative is ready.
+        </p>
+        <div class="grid">
+          <div>
+            Classic
+            <pre data-src="code/mixins/classic.js"></pre>
+          </div>
+          <div>
+            Octane
+            <p>
+              See 
+              <a href="https://www.pzuraq.com/do-you-need-ember-object/">
+                Do you need Ember Object?
+              </a>
+              for Mixin alternatives, such as utility functions, services, delegates, and class decorators.
+            </p>
           </div>
         </div>
       </section>

--- a/index.html
+++ b/index.html
@@ -37,11 +37,11 @@
         <div class="grid">
           <div>
             <h4>Classic</h4>
-            <pre data-src="code/generating-component/classic.handlebars"></pre>
+            <pre data-src="code/generating-component/classic.shell"></pre>
           </div>
           <div>
             <h4>Octane</h4>
-            <pre data-src="code/generating-component/octane.handlebars"></pre>
+            <pre data-src="code/generating-component/octane.shell"></pre>
           </div>
         </div>
       </section>
@@ -282,13 +282,17 @@
 
 
       <section aria-labelledby="section-boilerplate">
-        <h3 id="section-boilerplate">Boilerplate</h3>
+        <h3 id="section-boilerplate">Component JavaScript Syntax</h3>
         <p>
           An Octane component imports from the @glimmer package namespace, and it
-          uses Native Classes. Glimmer components have different API methods. (<a
-            href="https://octane-guides-preview.emberjs.com/release/components/#toc_component-classes"
-            >Learn more</a
-          >)
+          uses Native Class syntax. Glimmer components have different API methods than those on the classic @ember/component. If you aren't familiar with Native Classes, first check out the the 
+          <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes">
+            documentation on MDN
+          </a>.
+          Then, learn more about
+          <a href="https://octane-guides-preview.emberjs.com/release/components/#toc_component-classes">
+            Octane component classes
+          </a>.
         </p>
         <div class="grid">
           <div>
@@ -320,8 +324,48 @@
         </div>
       </section>
 
+      <section aria-labelledby="section-data-down-actions-up">
+        <h3 id="section-data-down-actions-up">Data Down, Actions Up</h3>
+        <p>
+          Octane components enforce "Data Down, Actions Up." That means that when data is passed down to a component, the only way to change that data is by using an action that was passed in as well. Said another way, there is no two-way binding of component arguments.
+        </p>
+        <div class="grid">
+          <div>
+            <h4>Classic</h4>
+            <pre data-src="code/ddau/classic-parent.js"></pre>
+            <pre data-src="code/ddau/classic-parent.handlebars"></pre>
+            <pre data-src="code/ddau/classic-child.js"></pre>
+            <pre data-src="code/ddau/classic-child.handlebars"></pre>
+          </div>
+          <div>
+            <h4>Octane</h4>
+            <pre data-src="code/ddau/octane-parent.js"></pre>
+            <pre data-src="code/ddau/octane-parent.handlebars"></pre>
+            <pre data-src="code/ddau/octane-child.handlebars"></pre>
+          </div>
+        </div>
+      </section>
+
+      <section aria-labelledby="section-data-get-and-set">
+          <h3 id="section-data-down-actions-up">Get and Set</h3>
+          <p>
+            Octane components do not use this.get or this.set.
+            Access and modify properties directly, the same as you would in a regular JavaScript Class.
+          </p>
+          <div class="grid">
+            <div>
+              <h4>Classic</h4>
+              <pre data-src="code/get-and-set/classic.js"></pre>
+            </div>
+            <div>
+              <h4>Octane</h4>
+              <pre data-src="code/get-and-set/octane.js"></pre>
+            </div>
+          </div>
+        </section>
+
       <section aria-labelledby="section-tracked">
-        <h3 id="section-tracked">Use @tracked instead of set, get, and computed</h3>
+        <h3 id="section-tracked">Use @tracked and getters instead of computed properties</h3>
         <p>
           Label the properties that should be tracked to compute another property,
           which is a getter.

--- a/index.html
+++ b/index.html
@@ -206,23 +206,6 @@
         </div>
       </section>
 
-    <section aria-labelledby="section-default-args">
-      <h3 id="section-default-args">Specifying a default value for an argument</h3>
-      <p>Because arguments are read only, their values cannot be changed so no default value can be set. To have a default-value-like experience, native getters may be used.</p>
-      <div class="grid">
-        <div>
-          Classic
-          <pre data-src="code/template-arguments-default/classic.handlebars"></pre>
-          <pre data-src="code/template-arguments-default/classic.js"></pre>
-        </div>
-        <div>
-          Octane
-          <pre data-src="code/template-arguments-default/octane.handlebars"></pre>
-          <pre data-src="code/template-arguments-default/octane.js"></pre>
-        </div>
-      </div>
-    </section>
-
       <section aria-labelledby="section-tagless-components">
         <h3 id="section-tagless-components">All components are tagless</h3>
         <p>
@@ -309,9 +292,7 @@
       <section aria-labelledby="section-computed-decorators">
         <h3 id="section-computed-decorators">Computed decorators</h3>
         <p>
-          Do you love that computed properties have to name their dependent keys?
-          I don't. But you could use the @computed decorator instead of @tracked
-          if you want.
+          For Octane, it is recommended to refactor computed properties to use tracked instead. However, there is a @computed decorator available as well.
         </p>
         <div class="grid">
           <div>
@@ -360,6 +341,22 @@
         </div>
       </section>
 
+      <section aria-labelledby="section-default-args">
+        <h3 id="section-default-args">Specifying a default value for an argument</h3>
+        <p>Because arguments are read only, their values cannot be changed so no default value can be set. To have a default-value-like experience, native getters may be used.</p>
+        <div class="grid">
+          <div>
+            Classic
+            <pre data-src="code/template-arguments-default/classic.handlebars"></pre>
+            <pre data-src="code/template-arguments-default/classic.js"></pre>
+          </div>
+          <div>
+            Octane
+            <pre data-src="code/template-arguments-default/octane.handlebars"></pre>
+            <pre data-src="code/template-arguments-default/octane.js"></pre>
+          </div>
+        </div>
+      </section>
 
       <h2 id="component-lifecycle"><a href="#component-lifecycle" title="Component Lifecycle" class="permalink">&sect;</a>Component Lifecycle</h2>
 

--- a/index.html
+++ b/index.html
@@ -347,7 +347,7 @@
       </section>
 
       <section aria-labelledby="section-data-get-and-set">
-          <h3 id="section-data-down-actions-up">Get and Set</h3>
+          <h3 id="section-data-down-actions-up">No more get and set on components</h3>
           <p>
             Octane components do not use this.get or this.set.
             Access and modify properties directly, the same as you would in a regular JavaScript Class.

--- a/index.html
+++ b/index.html
@@ -23,6 +23,24 @@
         >
       </p>
 
+      <h2 id="generating-files"><a href="#generating-files" title="Generating Files" class="permalink">&sect;</a>Generating Files</h2>
+
+      <section aria-labelledby="section-generating-component-class">
+        <h3 id="section-generating-component-class">Generating a Component's Class</h3>
+        <p>
+          In classic Ember, "ember generate component" created three files: the template, a JavaScript file, and a test. In Octane, "ember generate component" creates only a template. If you want the backing JavaScript Class as well, include an option.
+        </p>
+        <div class="grid">
+          <div>
+            <h4>Classic</h4>
+            <pre data-src="code/generating-component/classic.handlebars"></pre>
+          </div>
+          <div>
+            <h4>Octane</h4>
+            <pre data-src="code/generating-component/octane.handlebars"></pre>
+          </div>
+        </div>
+      </section>
 
       <h2 id="component-templates"><a href="#component-templates" title="Component Templates" class="permalink">&sect;</a>Component Templates</h2>
 
@@ -471,6 +489,25 @@
           <div>
             <h4>Octane</h4>
             <pre data-src="code/will-destroy/octane.js"></pre>
+          </div>
+        </div>
+      </section>
+
+      <h2 id="component-lifecycle"><a href="#component-lifecycle" title="Routes" class="permalink">&sect;</a>Routes</h2>
+
+      <section aria-labelledby="section-model-access">
+        <h3 id="section-model-access">Accessing a route's model</h3>
+        <p>
+          The model used in a route template has always come from an outside context. For this reason, in Octane, refer to it as @model.
+        </p>
+        <div class="grid">
+          <div>
+            <h4>Classic</h4>
+            <pre data-src="code/model-access/classic.handlebars"></pre>
+          </div>
+          <div>
+            <h4>Octane</h4>
+            <pre data-src="code/model-access/octane.handlebars"></pre>
           </div>
         </div>
       </section>

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
       <h2 id="generating-files"><a href="#generating-files" title="Generating Files" class="permalink">&sect;</a>Generating Files</h2>
 
       <section aria-labelledby="section-generating-component-class">
-        <h3 id="section-generating-component-class">Generating a Component's Class</h3>
+        <h3 id="section-generating-component-class">Use an option to generate a component's JavaScript</h3>
         <p>
           In classic Ember, "ember generate component" created three files: the template, a JavaScript file, and a test. In Octane, "ember generate component" creates only a template. If you want the backing JavaScript Class as well, include an option.
         </p>
@@ -38,6 +38,23 @@
           <div>
             <h4>Octane</h4>
             <pre data-src="code/generating-component/octane.handlebars"></pre>
+          </div>
+        </div>
+      </section>
+
+      <section aria-labelledby="section-file-structure">
+        <h3 id="section-file-structure">Component templates and JavaScript are in the same directory</h3>
+        <p>
+          The location of component templates has changed in Octane. This is known as "template co-location."
+        </p>
+        <div class="grid">
+          <div>
+            <h4>Classic</h4>
+            <pre data-src="code/file-structure/classic.text"></pre>
+          </div>
+          <div>
+            <h4>Octane</h4>
+            <pre data-src="code/file-structure/octane.text"></pre>
           </div>
         </div>
       </section>

--- a/index.html
+++ b/index.html
@@ -65,14 +65,14 @@
         <h3 id="section-anglebracketinvocation">Angle Brackets Component Invocation</h3>
         <p>
           Angle brackets are a way to invoke components in a template file.
-          There's no change in behavior. (<a
+          There's no change in behavior. Learn more about
+          <a
             href="https://octane-guides-preview.emberjs.com/release/components/"
-            >Learn more</a
-          >
-          |
-          <a href="https://github.com/ember-codemods/ember-angle-brackets-codemod"
-            >Automation</a
-          >)
+            >features</a> and 
+          <a href="https://octane-guides-preview.emberjs.com/release/upgrading/#toc_octane-upgrade-strategy">
+            using codemods
+          </a>
+          to update your existing components.
         </p>
         <div class="grid">
           <div>
@@ -91,14 +91,15 @@
         <p>
           Angle brackets components can be used as either inline or block
           components. There's no change in behavior. {{yield}} looks and works
-          the same. (<a
+          the same.
+          Learn more about
+          <a
             href="https://octane-guides-preview.emberjs.com/release/components/yields/"
-            >Learn more</a
-          >
-          |
-          <a href="https://github.com/ember-codemods/ember-angle-brackets-codemod"
-            >Automation</a
-          >)
+            >features</a> and 
+          <a href="https://octane-guides-preview.emberjs.com/release/upgrading/#toc_octane-upgrade-strategy">
+            using codemods
+          </a>
+          to update your existing components.
         </p>
         <div class="grid">
           <div>
@@ -117,14 +118,6 @@
         <p>
           You can nest components in your file structure, and use them in a
           template with Angle Brackets invocation. There's no change in behavior.
-          (<a
-            href="https://guides.emberjs.com/release/reference/syntax-conversion-guide/"
-            >Learn more</a
-          >
-          |
-          <a href="https://github.com/ember-codemods/ember-angle-brackets-codemod"
-            >Automation</a
-          >)
         </p>
         <div class="grid">
           <div>
@@ -142,13 +135,10 @@
         <h3 id="section-named-args">Using named arguments</h3>
         <p>
           If a property was received from a parent component, refer to it with an
-          @. There's no change in behavior. (<a
+          @. There's no change in behavior.
+          (<a
             href="https://octane-guides-preview.emberjs.com/release/components/#toc_component-templates"
             >Learn more</a
-          >
-          |
-          <a href="https://github.com/ember-codemods/ember-angle-brackets-codemod"
-            >Automation</a
           >)
         </p>
         <div class="grid">
@@ -168,14 +158,15 @@
         <p>
           If a property is defined in the JavaScript file for this component's
           template, use a "this" when you refer to it. There's no change in
-          behavior. (<a
-            href="https://guides.emberjs.com/release/upgrading/edition"
-            >Learn more</a
-          >
-          |
-          <a href="https://github.com/ember-codemods/ember-no-implicit-this-codemod"
-            >Automation</a
-          >)
+          behavior.
+          Learn more about
+          <a
+            href="https://octane-guides-preview.emberjs.com/release/upgrading/current-edition/glimmer-components/"
+            >features</a> and 
+          <a href="https://guides.emberjs.com/release/upgrading/">
+            using codemods
+          </a>
+          to update your existing components.
         </p>
         <div class="grid">
           <div>
@@ -193,14 +184,15 @@
         <h3 id="section-passing-named-args">Passing named arguments</h3>
         <p>
           When you pass an argument to a component, use an `@` symbol on the left
-          hand side. There's no change in behavior. (<a
+          hand side. There's no change in behavior.
+          Learn more about
+          <a
             href="https://octane-guides-preview.emberjs.com/release/components/#toc_component-templates"
-            >Learn more</a
-          >
-          |
-          <a href="https://github.com/ember-codemods/ember-angle-brackets-codemod"
-            >Automation</a
-          >)
+            >features</a> and 
+          <a href="https://guides.emberjs.com/release/upgrading/">
+            using codemods
+          </a>
+          to update your existing components.
         </p>
         <div class="grid">
           <div>
@@ -220,14 +212,15 @@
         <h3 id="section-passing-args-this-component">Passing arguments defined on "this" component</h3>
         <p>
           If a property is coming from a template's own JavaScript file, remember
-          to put a "this." before it and wrap it in curly braces. (<a
+          to put a "this." before it and wrap it in curly braces.
+          Learn more about
+          <a
             href="https://octane-guides-preview.emberjs.com/release/components/#toc_component-templates"
-            >Learn more</a
-          >
-          |
-          <a href="https://github.com/ember-codemods/ember-angle-brackets-codemod"
-            >Automation</a
-          >)
+            >features</a> and 
+          <a href="https://guides.emberjs.com/release/upgrading/">
+            using codemods
+          </a>
+          to update your existing components.
         </p>
         <div class="grid">
           <div>
@@ -291,8 +284,7 @@
           uses Native Classes. Glimmer components have different API methods. (<a
             href="https://octane-guides-preview.emberjs.com/release/components/#toc_component-classes"
             >Learn more</a
-          >
-          | <a href="https://github.com/ember-codemods/ember-native-class-codemod">Automation</a>)
+          >)
         </p>
         <div class="grid">
           <div>
@@ -443,8 +435,7 @@
           constructor is a feature of JavaScript Native Classes, not something
           Ember made up. Use it instead of init. No more this.set! (<a href="https://octane-guides-preview.emberjs.com/release/components/#toc_component-hooks-and-properties"
             >Learn more</a
-          >
-          | <a href="https://github.com/ember-codemods/ember-native-class-codemod">Automation</a>)
+          >)
         </p>
         <div class="grid">
           <div>


### PR DESCRIPTION
Closes #18 

Please let me know if anything is missing or confusing! The best way to review this is to look at the screenshot below or run this app locally.

Changed:
- replaced Avatar references 😭 
- Moved "default properties" into the Component Properties section
- Replaced "Automation" links that went to codemods with links to the upgrade guide instead.

Added
- Section on mixins
- Section on generating element ids
- Link to the upgrade guides in the intro text
- Section on `@model`
- Section on component generators
- section on template co-location
- separate section on get and set
- section on DDAU