### PR TITLE
Make component constructor arguments explicit

### DIFF
--- a/code/constructors/octane.js
+++ b/code/constructors/octane.js
@@ -1,8 +1,8 @@
 import Component from '@glimmer/component';
 
 export default class SomeComponent extends Component {
-  constructor() {
-    super(...arguments);
+  constructor(owner, args) {
+    super(owner, args);
     this.answer = 42;
   }
 }


### PR DESCRIPTION
With classic components, it was my understanding that the arguments to `init` / the constructor were private API and that is why they were to be opaquely passed thru using `...arguments`. However, the public API for [glimmer components](https://api.emberjs.com/ember/release/modules/@glimmer%2Fcomponent) specifies that it takes exactly 2: `owner` and `args`, so it seems like it would be better to make this explicit. This also helps avoid errors/warnings when using TypeScript.