### PR TITLE
Preliminary work for translating the Octane cheatsheet to French

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,6 +1,14 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class ApplicationRoute extends Route {
+
+  @service intl;
+
+  beforeModel() {
+    this.intl.setLocale(["fr-fr"]);
+  }
+
   model() {
     return [
       {

--- a/translations/fr-fr.yaml
+++ b/translations/fr-fr.yaml
@@ -1,0 +1,149 @@
+layout:
+  application:
+    logo-alt-text: "Ember Octane: the latest edition from Ember.js"
+    title: Ember.js Octane vs Classic Cheat Sheet
+    description: 
+      "<p class=\"intro\">
+        This guide is a cheat sheet for using <a href=\"https://emberjs.com/editions/octane\" target=\"_blank\" rel=\"noopener noreferrer\">Ember.js Octane</a>. It doesn't cover everything, but it should get you started! PRs welcome at <a href=\"https://github.com/jenweber/ember-octane-vs-classic-cheat-sheet\" target=\"_blank\" rel=\"noopener noreferrer\">the GitHub repository</a>.
+      </p>
+      <p>
+        For in-depth information about the upgrade paths and differences introduced in Octane, see <a href=\"https://guides.emberjs.com/release/upgrading/\" target=\"_blank\" rel=\"noopener noreferrer\">The Octane Upgrading Guide</a>.
+      </p>"
+
+
+component:
+  guide-section:
+    section: §
+    subsection:
+      classic: Classic
+      octane: Octane
+
+
+generating-files:
+  title: Generating Files
+
+  generating-component:
+    title: Use an option to generate a component's JavaScript
+    description: "In classic Ember, \"ember generate component\" created three files: the template, a JavaScript file, and a test. In Octane, \"ember generate component\" creates only a template. If you want the backing JavaScript Class as well, include an option."
+
+  file-structure:
+    title: Component templates and JavaScript are in the same directory
+    description: "The location of component templates has changed in Octane. This is known as \"template co-location.\""
+
+
+component-templates:
+  title: Component Templates
+
+  angle-brackets:
+    title: Angle brackets component invocation
+    description: "Angle brackets are a way to invoke components in a template file. There's no change in behavior. Learn more about <a href=\"https://guides.emberjs.com/release/components/\" target=\"_blank\" rel=\"noopener noreferrer\">features</a> and <a href=\"https://guides.emberjs.com/release/upgrading/current-edition/#toc_octane-upgrade-strategy\" target=\"_blank\" rel=\"noopener noreferrer\">using codemods</a> to update your existing components."
+
+  inline-vs-block:
+    title: Inline vs block components
+    description: "Angle brackets components can be used as either inline or block components. There's no change in behavior. \\{\\{yield\\}\\} looks and works the same. Learn more about <a href=\"https://guides.emberjs.com/release/components/block-content/\" target=\"_blank\" rel=\"noopener noreferrer\">features</a> and <a href=\"https://guides.emberjs.com/release/upgrading/current-edition/\" target=\"_blank\" rel=\"noopener noreferrer\">using codemods</a> to update your existing components."
+
+  angle-brackets-nested:
+    title: Nesting components in your file structure
+    description: You can nest components in your file structure, and use them in a template with Angle Brackets invocation. There's no change in behavior.
+
+  template-named:
+    title: Using named argument
+    description: "If a property was received from a parent component, refer to it with an @. There's no change in behavior. (<a href=\"https://guides.emberjs.com/release/components/component-arguments-and-html-attributes/\" target=\"_blank\" rel=\"noopener noreferrer\">Visit the Ember Guides to learn more</a>.)"
+
+  template-this:
+    title: Using own properties
+    description: "If a property is defined in the JavaScript file for this component's template, use a \"this\" when you refer to it. There's no change in behavior. Learn more about <a href=\"https://guides.emberjs.com/release/upgrading/current-edition/glimmer-components/\" target=\"_blank\" rel=\"noopener noreferrer\">features</a> and <a href=\"https://guides.emberjs.com/release/upgrading/\" target=\"_blank\" rel=\"noopener noreferrer\">using codemods</a> to update your existing components."
+
+  template-arguments-named:
+    title: Passing named arguments
+    description: "When you pass an argument to a component, use an @ symbol on the left hand side. There's no change in behavior. Learn more about <a href=\"https://guides.emberjs.com/release/components/component-arguments-and-html-attributes/\" target=\"_blank\" rel=\"noopener noreferrer\">features</a> and <a href=\"https://guides.emberjs.com/release/upgrading/\" target=\"_blank\" rel=\"noopener noreferrer\">using codemods</a> to update your existing components."
+
+  template-arguments-this:
+    title: "Passing arguments defined on \"this\" component"
+    description: "If a property is coming from a template's own JavaScript file, remember to put a \"this.\" before it and wrap it in curly braces. Learn more about <a href=\"https://guides.emberjs.com/release/components/component-arguments-and-html-attributes/\" target=\"_blank\" rel=\"noopener noreferrer\">features</a> and <a href=\"https://guides.emberjs.com/release/upgrading/\" target=\"_blank\" rel=\"noopener noreferrer\">using codemods</a> to update your existing components."
+
+  tag-name:
+    title: All components are tagless
+    description: In Octane, components don't have a default wrapper anymore, so you don't need tagName! Just put the tag right in the template.
+
+  element-id:
+    title: Make your own elementId
+    description: Since components are tagless, there's no elementId, but you can generate your own. This is especially helpful for creating accessible forms.
+
+
+component-properties:
+  title: Component Properties
+
+  js-boilerplate:
+    title: Component JavaScript Syntax
+    description: "An Octane component imports from the @glimmer package namespace, and it uses Native Class syntax. Glimmer components have different API methods than those on the classic @ember/component. If you aren't familiar with Native Classes, first check out the <a href=\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes\" target=\"_blank\" rel=\"noopener noreferrer\">documentation on MDN</a>. Then, learn more about <a href=\"https://guides.emberjs.com/release/components/component-state-and-actions/\" target=\"_blank\" rel=\"noopener noreferrer\">Octane component classes</a> and the <a href=\"https://api.emberjs.com/ember/release/modules/@glimmer%2Fcomponent\" target=\"_blank\" rel=\"noopener noreferrer\">Component API Documentation</a>."
+
+  js-properties:
+    title: Declaring a property
+    description: Properties follow normal Native JavaScript Class syntax. Look ma, no commas!
+
+  ddau:
+    title: Data Down, Actions Up
+    description: "Octane components enforce \"Data Down, Actions Up.\" That means that when data is passed down to a component, the only way to change that data is by using an action that was passed in as well. Said another way, there is no two-way binding of component arguments."
+
+  get-and-set:
+    title: No more get and set on components
+    description: Octane components do not use this.get or this.set. Access and modify properties directly, the same as you would in a regular JavaScript Class.
+
+  tracked-vs-cp:
+    title: Use @tracked and getters instead of computed properties
+    description: Label the properties that should be tracked to compute another property,
+      which is a getter.
+
+  computed-decorator:
+    title: Computed decorators
+    description: For Octane, it is recommended to refactor computed properties to use tracked instead. However, there is a @computed decorator available as well.
+
+
+actions:
+  title: Actions
+
+  actions:
+    title: Use @action, on, and fn instead of action
+    description: "Use the @action decorator in your JavaScript to indicate functions that you want to be able to use in a template. Use those functions in the template with \"on,\" and if you need to pass an argument to the function, use \"fn\" too. (<a href=\"https://guides.emberjs.com/release/components/component-state-and-actions/#toc_html-modifiers-and-actions\" target=\"_blank\" rel=\"noopener noreferrer\">Visit the Ember Guides to learn more</a>.)"
+
+  template-arguments-default:
+    title: Specifying a default value for an argument
+    description: Because arguments are read only, their values cannot be changed so no default value can be set. To have a default-value-like experience, native getters may be used.
+
+  mixins:
+    title: Mixins
+    description: You cannot use mixins on anything that uses Native Class syntax (such as components that import from @glimmer/component). The replacement strategy depends on your use case. If your app depends on an addon that uses Mixins, it may be best to continue using classic components until an alternative is ready.
+    octaneDescription: "See <a href=\"https://www.pzuraq.com/do-you-need-ember-object/\" target=\"_blank\" rel=\"noopener noreferrer\">Do you need Ember Object?</a> for Mixin alternatives, such as utility functions, services, delegates, and class decorators."
+
+
+component-lifecycle:
+  title: Component Lifecycle
+
+  constructors:
+    title: Using constructor instead of init
+    description: "constructor is a feature of JavaScript Native Classes, not something Ember made up. Use it instead of init. No more this.set! (<a href=\"https://guides.emberjs.com/release/components/component-state-and-actions/\" target=\"_blank\" rel=\"noopener noreferrer\">Visit the Ember Guides to learn more</a>.)"
+
+  render-modifiers:
+    title: Element Modifiers
+    description:
+      "<p>There are three new element modifiers, \\{\\{did-insert\\}\\}, \\{\\{did-update\\}\\}, and \\{\\{will-destroy\\}\\}, that you may use to replace the classic component lifecycle hooks didInsertElement, willDestroy, and didUpdate.
+      </p>
+      <p>
+        In order for these modifiers to work, you need to install the <a href=\"https://github.com/emberjs/ember-render-modifiers\" target=\"_blank\" rel=\"noopener noreferrer\">@ember/render-modifiers package</a>.
+      </p>"
+
+  did-insert:
+    title: Use element modifiers instead of didInsertElement
+    description: "Instead of writing a didInsertElement method in the JavaScript file, put the \\{\\{did-insert\\}\\} modifier in your template and say which function to call when that element is rendered. Label that function with the @action decorator. (<a href=\"https://guides.emberjs.com/release/components/template-lifecycle-dom-and-modifiers/\" target=\"_blank\" rel=\"noopener noreferrer\">Visit the Ember Guides to learn more</a>.)"
+
+  will-destroy:
+    title: Using willDestroy
+    description: "willDestroy is called when the entire component's element will be destroyed, similar to willDestroyElement. You can use it as a method like below, or via a modifier similar to \\{\\{did-insert\\}\\} just above. (<a href=\"https://guides.emberjs.com/release/components/template-lifecycle-dom-and-modifiers/\" target=\"_blank\" rel=\"noopener noreferrer\">Visit the Ember Guides to learn more</a>.)"
+
+routes:
+  title: Routes
+
+  model-access:
+    title: Accessing a route's model
+    description: The model used in a route template has always come from an outside context. For this reason, in Octane, refer to it as @model.

--- a/translations/fr-fr.yaml
+++ b/translations/fr-fr.yaml
@@ -47,8 +47,8 @@ component-templates:
     description: Vous pouvez «nester» les composants dans votre codebase et les utiliser dans un template via l'invocation «Angle brackets». Les fonctionnalités seront identiques.
 
   template-named:
-    title: Using named argument
-    description: "If a property was received from a parent component, refer to it with an @. There's no change in behavior. (<a href=\"https://guides.emberjs.com/release/components/component-arguments-and-html-attributes/\" target=\"_blank\" rel=\"noopener noreferrer\">Visit the Ember Guides to learn more</a>.)"
+    title: Utiliser les arguments nommés
+    description: "Quand vous faites référence à une propriété précisée lors de l'invocation, elle doit être préfixée d'un «@». Fonctionnellement, cela n'a aucun impact. (<a href=\"https://guides.emberjs.com/release/components/component-arguments-and-html-attributes/\" target=\"_blank\" rel=\"noopener noreferrer\">Consultez les «Ember Guides» pour en savoir plus</a>.)"
 
   template-this:
     title: Using own properties

--- a/translations/fr-fr.yaml
+++ b/translations/fr-fr.yaml
@@ -51,8 +51,8 @@ component-templates:
     description: "Quand vous faites référence à une propriété précisée lors de l'invocation, elle doit être préfixée d'un «@». Fonctionnellement, cela n'a aucun impact. (<a href=\"https://guides.emberjs.com/release/components/component-arguments-and-html-attributes/\" target=\"_blank\" rel=\"noopener noreferrer\">Consultez les «Ember Guides» pour en savoir plus</a>.)"
 
   template-this:
-    title: Using own properties
-    description: "If a property is defined in the JavaScript file for this component's template, use a \"this\" when you refer to it. There's no change in behavior. Learn more about <a href=\"https://guides.emberjs.com/release/upgrading/current-edition/glimmer-components/\" target=\"_blank\" rel=\"noopener noreferrer\">features</a> and <a href=\"https://guides.emberjs.com/release/upgrading/\" target=\"_blank\" rel=\"noopener noreferrer\">using codemods</a> to update your existing components."
+    title: Utiliser les propriétés d'un composant
+    description: "Lorsqu'une propriété est définie dans le fichier JavaScript d'un composant, elle doit être préfixée par «this.» lorsque vous y faites référence dans le template du composant. Fonctionnellement, cela n'a aucun impact. Pour en savoir plus <a href=\"https://guides.emberjs.com/release/upgrading/current-edition/glimmer-components/\" target=\"_blank\" rel=\"noopener noreferrer\">features</a> and <a href=\"https://guides.emberjs.com/release/upgrading/\" target=\"_blank\" rel=\"noopener noreferrer\">les codemods</a> pour migrer vos composants."
 
   template-arguments-named:
     title: Passing named arguments

--- a/translations/fr-fr.yaml
+++ b/translations/fr-fr.yaml
@@ -55,8 +55,8 @@ component-templates:
     description: "Lorsqu'une propriété est définie dans le fichier JavaScript d'un composant, elle doit être préfixée par «this.» lorsque vous y faites référence dans le template du composant. Fonctionnellement, cela n'a aucun impact. Pour en savoir plus <a href=\"https://guides.emberjs.com/release/upgrading/current-edition/glimmer-components/\" target=\"_blank\" rel=\"noopener noreferrer\">features</a> and <a href=\"https://guides.emberjs.com/release/upgrading/\" target=\"_blank\" rel=\"noopener noreferrer\">les codemods</a> pour migrer vos composants."
 
   template-arguments-named:
-    title: Passing named arguments
-    description: "When you pass an argument to a component, use an @ symbol on the left hand side. There's no change in behavior. Learn more about <a href=\"https://guides.emberjs.com/release/components/component-arguments-and-html-attributes/\" target=\"_blank\" rel=\"noopener noreferrer\">features</a> and <a href=\"https://guides.emberjs.com/release/upgrading/\" target=\"_blank\" rel=\"noopener noreferrer\">using codemods</a> to update your existing components."
+    title: Les arguments nommés lors de l'invocation
+    description: "Lorsque vous fournissez un argument à un composant lors de l'invocation, préfixez le nom de cet argument par un «@». Fonctionnellement, cela n'a aucun impact. Pour en savoir plus <a href=\"https://guides.emberjs.com/release/components/component-arguments-and-html-attributes/\" target=\"_blank\" rel=\"noopener noreferrer\">features</a> and <a href=\"https://guides.emberjs.com/release/upgrading/\" target=\"_blank\" rel=\"noopener noreferrer\">les codemods</a> pour migrer vos composants."
 
   template-arguments-this:
     title: "Passing arguments defined on \"this\" component"

--- a/translations/fr-fr.yaml
+++ b/translations/fr-fr.yaml
@@ -2,12 +2,12 @@ layout:
   application:
     logo-alt-text: "Ember Octane: the latest edition from Ember.js"
     title: Ember.js Octane vs Classic Cheat Sheet
-    description: 
+    description:
       "<p class=\"intro\">
-        This guide is a cheat sheet for using <a href=\"https://emberjs.com/editions/octane\" target=\"_blank\" rel=\"noopener noreferrer\">Ember.js Octane</a>. It doesn't cover everything, but it should get you started! PRs welcome at <a href=\"https://github.com/jenweber/ember-octane-vs-classic-cheat-sheet\" target=\"_blank\" rel=\"noopener noreferrer\">the GitHub repository</a>.
+        Ce guide est un aide-mémoire (eng: cheat sheet) afin d'utiliser <a href=\"https://emberjs.com/editions/octane\" target=\"_blank\" rel=\"noopener noreferrer\">Ember.js Octane</a>. Tout n'y est pas abordé, mais il devrait permettre de bien démarrer avec Octane! Toutes les PRs sont les bienvenues sur <a href=\"https://github.com/jenweber/ember-octane-vs-classic-cheat-sheet\" target=\"_blank\" rel=\"noopener noreferrer\">le repository GitHub</a>.
       </p>
       <p>
-        For in-depth information about the upgrade paths and differences introduced in Octane, see <a href=\"https://guides.emberjs.com/release/upgrading/\" target=\"_blank\" rel=\"noopener noreferrer\">The Octane Upgrading Guide</a>.
+        Pour plus d'information sur la manière de migrer vers Octane et les nouveautés qui y sont introduites, consultez <a href=\"https://guides.emberjs.com/release/upgrading/\" target=\"_blank\" rel=\"noopener noreferrer\">Le guide de migration vers Octane</a>.
       </p>"
 
 

--- a/translations/fr-fr.yaml
+++ b/translations/fr-fr.yaml
@@ -39,8 +39,8 @@ component-templates:
     description: "«Angle brackets» est une manière d'invoquer un/des composants dans un fichier de templates. Fonctionnellement, cela n'a aucun impact. Pour en savoir plus : <a href=\"https://guides.emberjs.com/release/components/\" target=\"_blank\" rel=\"noopener noreferrer\">features</a> et <a href=\"https://guides.emberjs.com/release/upgrading/current-edition/#toc_octane-upgrade-strategy\" target=\"_blank\" rel=\"noopener noreferrer\">les codemods</a> pour migrer vos composants."
 
   inline-vs-block:
-    title: Inline vs block components
-    description: "Angle brackets components can be used as either inline or block components. There's no change in behavior. \\{\\{yield\\}\\} looks and works the same. Learn more about <a href=\"https://guides.emberjs.com/release/components/block-content/\" target=\"_blank\" rel=\"noopener noreferrer\">features</a> and <a href=\"https://guides.emberjs.com/release/upgrading/current-edition/\" target=\"_blank\" rel=\"noopener noreferrer\">using codemods</a> to update your existing components."
+    title: Composants inline vs composants block
+    description: "Vous pouvez invoquer un composant «Angle brackets» inline ou bien sous forme de block. Le fonctionnement ne sera pas affecté. \\{\\{yield\\}\\} se comporte de la même manière. Pour en savoir plus : <a href=\"https://guides.emberjs.com/release/components/block-content/\" target=\"_blank\" rel=\"noopener noreferrer\">features</a> et <a href=\"https://guides.emberjs.com/release/upgrading/current-edition/\" target=\"_blank\" rel=\"noopener noreferrer\">les codemods</a> pour migrer vos composants."
 
   angle-brackets-nested:
     title: Nesting components in your file structure

--- a/translations/fr-fr.yaml
+++ b/translations/fr-fr.yaml
@@ -20,11 +20,11 @@ component:
 
 
 generating-files:
-  title: Generating Files
+  title: Génération de fichiers
 
   generating-component:
-    title: Use an option to generate a component's JavaScript
-    description: "In classic Ember, \"ember generate component\" created three files: the template, a JavaScript file, and a test. In Octane, \"ember generate component\" creates only a template. If you want the backing JavaScript Class as well, include an option."
+    title: Utiliser une option pour générer le fichier JavaScript d'un composant
+    description: "Avec Ember classic, \"ember generate component\" générait trois fichiers: le template, un fichier JavaScript et un test. Sous Octane, \"ember generate component\" crée uniquement un template. Si vous souhaitez également générer le fichier JavaScript définissant la Class, vous devez préciser une option."
 
   file-structure:
     title: Component templates and JavaScript are in the same directory

--- a/translations/fr-fr.yaml
+++ b/translations/fr-fr.yaml
@@ -43,8 +43,8 @@ component-templates:
     description: "Vous pouvez invoquer un composant «Angle brackets» inline ou bien sous forme de block. Le fonctionnement ne sera pas affecté. \\{\\{yield\\}\\} se comporte de la même manière. Pour en savoir plus : <a href=\"https://guides.emberjs.com/release/components/block-content/\" target=\"_blank\" rel=\"noopener noreferrer\">features</a> et <a href=\"https://guides.emberjs.com/release/upgrading/current-edition/\" target=\"_blank\" rel=\"noopener noreferrer\">les codemods</a> pour migrer vos composants."
 
   angle-brackets-nested:
-    title: Nesting components in your file structure
-    description: You can nest components in your file structure, and use them in a template with Angle Brackets invocation. There's no change in behavior.
+    title: «Nester» les composants dans le système de fichiers
+    description: Vous pouvez «nester» les composants dans votre codebase et les utiliser dans un template via l'invocation «Angle brackets». Les fonctionnalités seront identiques.
 
   template-named:
     title: Using named argument

--- a/translations/fr-fr.yaml
+++ b/translations/fr-fr.yaml
@@ -27,16 +27,16 @@ generating-files:
     description: "Avec Ember classic, \"ember generate component\" générait trois fichiers: le template, un fichier JavaScript et un test. Sous Octane, \"ember generate component\" crée uniquement un template. Si vous souhaitez également générer le fichier JavaScript définissant la Class, vous devez préciser une option."
 
   file-structure:
-    title: Component templates and JavaScript are in the same directory
-    description: "The location of component templates has changed in Octane. This is known as \"template co-location.\""
+    title: Les fichiers .hbs et .js d'un composant sont placés dans le même dossier
+    description: "Avec Octane, l'emplacement du template d'un composant a changé. Nous parlons maintenant de \"template co-location.\""
 
 
 component-templates:
-  title: Component Templates
+  title: Templates des composants
 
   angle-brackets:
-    title: Angle brackets component invocation
-    description: "Angle brackets are a way to invoke components in a template file. There's no change in behavior. Learn more about <a href=\"https://guides.emberjs.com/release/components/\" target=\"_blank\" rel=\"noopener noreferrer\">features</a> and <a href=\"https://guides.emberjs.com/release/upgrading/current-edition/#toc_octane-upgrade-strategy\" target=\"_blank\" rel=\"noopener noreferrer\">using codemods</a> to update your existing components."
+    title: Invocation «Angle brackets» des composants
+    description: "«Angle brackets» est une manière d'invoquer un/des composants dans un fichier de templates. Fonctionnellement, cela n'a aucun impact. Pour en savoir plus : <a href=\"https://guides.emberjs.com/release/components/\" target=\"_blank\" rel=\"noopener noreferrer\">features</a> et <a href=\"https://guides.emberjs.com/release/upgrading/current-edition/#toc_octane-upgrade-strategy\" target=\"_blank\" rel=\"noopener noreferrer\">les codemods</a> pour migrer vos composants."
 
   inline-vs-block:
     title: Inline vs block components


### PR DESCRIPTION
This PR is an attempt to provide the `fr-fr` locale translations.

Looks like the logic to set the locale is not yet present in the repo. For the time being, this PR does not implement this logic.

I do not see any other translation files yet in the repo, so please let me know if this PR is not going in the right direction 🙏