### PR TITLE
add links to subsections

### DIFF
--- a/app/components/guide-section/subsection/template.hbs
+++ b/app/components/guide-section/subsection/template.hbs
@@ -12,6 +12,9 @@
       data-test-field="Subsection Title"
       id="{{@sectionId}}__{{subsectionId}}"
     >
+      <a href="#{{@sectionId}}__{{subsectionId}}" title={{subsectionTitle}} class="permalink">
+        {{t "component.guide-section.section"}}
+      </a>
       {{subsectionTitle}}
     </h3>
 

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -63,8 +63,11 @@ h2 + section {
   margin-top: 1em;
 }
 .permalink {
-  color: #c1c1c1;
+  color: #1c304a33;
   text-decoration: none;
+}
+h2 .permalink {
+  color: #c1c1c1;
   padding: 0 15px 0 5px;
 }
 .intro {

--- a/tests/integration/components/guide-section/subsection/component-test.js
+++ b/tests/integration/components/guide-section/subsection/component-test.js
@@ -5,7 +5,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 // TODO: There may be a bug in ember-prism v0.7.0.
-// 
+//
 // Possibly due to its use of classic component and splattributes, I noticed that
 // the test selector for <CodeSnippet> appears twice in development and testing
 // environments. One on the <pre> tag and another on the <code> tag inside.
@@ -32,7 +32,7 @@ module('Integration | Component | guide-section/subsection', function(hooks) {
     `);
 
     assert.dom('[data-test-field="Subsection Title"]')
-      .hasText('Warning: Subsection title not found');
+      .hasText('§ Warning: Subsection title not found');
 
     assert.dom('[data-test-field="Subsection Description"]')
       .hasText('Warning: Subsection description not found');
@@ -69,7 +69,7 @@ module('Integration | Component | guide-section/subsection', function(hooks) {
     `);
 
     assert.dom('[data-test-field="Subsection Title"]')
-      .hasText('Use an option to generate a component\'s JavaScript');
+      .hasText('§ Use an option to generate a component\'s JavaScript');
 
     assert.dom('[data-test-field="Subsection Description"]')
       .includesText('In classic Ember, ember generate component created three files');
@@ -111,7 +111,7 @@ module('Integration | Component | guide-section/subsection', function(hooks) {
     `);
 
     assert.dom('[data-test-field="Subsection Title"]')
-      .hasText('Data Down, Actions Up');
+      .hasText('§ Data Down, Actions Up');
 
     assert.dom('[data-test-field="Subsection Description"]')
       .includesText('Octane components enforce "Data Down, Actions Up."');
@@ -146,7 +146,7 @@ module('Integration | Component | guide-section/subsection', function(hooks) {
     `);
 
     assert.dom('[data-test-field="Subsection Title"]')
-      .hasText('Mixins');
+      .hasText('§ Mixins');
 
     assert.dom('[data-test-field="Subsection Description"]')
       .includesText('You cannot use mixins on anything that uses native class syntax');


### PR DESCRIPTION
Hi there, here's a small contribution to address the following use case:
> I often find myself opening the browser's devtools to retrieve ids and crafting a URL with an anchor when I want to point a peer to a specific section of a webpage.

Note: 
- the anchor color is based on 0.2 opacity of the body text color.
- the existing anchor color and padding are now specific to h2's anchors

Cheers

![image](https://user-images.githubusercontent.com/3007703/88184868-8aa9be80-cc33-11ea-8dc3-8298e21e571d.png)
