### PR TITLE
Added a description for Classic subsection for Element Modifiers

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -237,8 +237,7 @@ export default class ApplicationRoute extends Route {
           },
           {
             id: 'render-modifiers',
-            classicFiles: [
-            ],
+            classicDescriptionKey: 'component-lifecycle.render-modifiers.classicDescription',
             octaneFiles: [
               'octane.shell'
             ]

--- a/translations/component-lifecycle/render-modifiers/en-us.yaml
+++ b/translations/component-lifecycle/render-modifiers/en-us.yaml
@@ -2,3 +2,6 @@ title: Element Modifiers
 description: >
   If you install '<a href="https://github.com/emberjs/ember-render-modifiers" target="_blank" rel="noopener noreferrer">'@ember/render-modifiers'</a>', you get '<code>{{did-insert}}</code>' and '<code>{{did-update}}</code>' modifiers.
   You may use them to replace a classic component's lifecycle hooks '<code>didInsertElement</code>', '<code>didRender</code>', and '<code>didUpdate</code>'.
+classicDescription: >
+  Have Ember apps at version 2.18 or higher?
+  You can use these modifiers to start converting classic components to Glimmer ones.


### PR DESCRIPTION
## Description

This PR addresses and can close #45.

I opted for adding a paragraph (i.e. a translation key) that explains that `@ember/render-modifiers` can still be used in classic apps as long as the Ember version is 2.18 or higher.

<img width="800" alt="screenshot" src="https://user-images.githubusercontent.com/16869656/89044541-b3a31100-d30f-11ea-9de5-418e4f1ff63c.png">


## Notes

The alternative approach that I had thought of was to update the `<GuideSection::Subsection>` component template to conditionally render a does-not-apply message. I thought adding the conditional logic,

```handlebars
{{#if (or @subsection.classicFiles @subsection.classicDescriptionKey)}}
  {{!-- Show classicFiles or classicDescriptionKey --}}
{{else}}
  {{!-- Show does-not-apply message --}}
{{/lf}}
```

one for Classic and yet another for Octane, might cause the template to be messy now or later.