### PR TITLE
Add args section to component-properties

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -152,6 +152,15 @@ export default class ApplicationRoute extends Route {
             ]
           },
           {
+            id: 'args',
+            classicFiles: [
+              'classic.js',
+            ],
+            octaneFiles:[
+              'octane.js',
+            ]
+          },
+          {
             id: 'get-and-set',
             classicFiles: [
               'classic.js'

--- a/snippets/component-properties/args/classic.js
+++ b/snippets/component-properties/args/classic.js
@@ -1,0 +1,18 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+
+export default Component.extend({
+  prefix: 'ISO',
+
+  displayName: computed('prefix,isoStandardNumber', function() {
+    /*
+      There are two issues with this code:
+
+      1. `prefix` may or may not be overriden from outside
+      2. We can't tell if `isoStandardNumber` is a property or an argument
+    */
+    return `${this.prefix} ${this.isoStandardNumber}`;
+  }),
+
+  /* Rest of the code omitted */
+});

--- a/snippets/component-properties/args/octane.js
+++ b/snippets/component-properties/args/octane.js
@@ -1,0 +1,12 @@
+
+import Component from '@glimmer/component';
+
+export default class MyComponent extends Component {
+  prefix = 'ISO';
+
+  get displayName() {
+    return `${this.prefix} ${this.args.isoStandardNumber}`;
+  }
+
+  /* Rest of the code omitted */
+}

--- a/snippets/component-properties/args/octane.js
+++ b/snippets/component-properties/args/octane.js
@@ -1,4 +1,3 @@
-
 import Component from '@glimmer/component';
 
 export default class MyComponent extends Component {

--- a/translations/component-properties/args/en-us.yaml
+++ b/translations/component-properties/args/en-us.yaml
@@ -1,4 +1,6 @@
 title: Component Arguments
-description: > 
-  In Octane, arguments passed to a component are set on a new `args` property, `this.args`, instead of being set directly on the class instance, `this`.
-  This avoids the possibility of overwriting methods and actions, and makes the distinction between internal class values and arguments much more clear. 
+description: >
+  In Octane, arguments are set on the '<code>'args'</code>' property, '<code>'this.args'</code>'.
+  They are '<em>'not'</em>' set on the class instance, '<code>'this'</code>'.
+  As a result, you can distinguish internal class values from external arguments.
+  (Visit the Ember Guides to learn more about '<a href="https://guides.emberjs.com/release/upgrading/current-edition/glimmer-components/#toc_arguments" target="_blank" rel="noopener noreferrer">'arguments'</a>'.)

--- a/translations/component-properties/args/en-us.yaml
+++ b/translations/component-properties/args/en-us.yaml
@@ -1,0 +1,4 @@
+title: Component Arguments
+description: > 
+  In Octane, arguments passed to a component are set on a new `args` property, `this.args`, instead of being set directly on the class instance, `this`.
+  This avoids the possibility of overwriting methods and actions, and makes the distinction between internal class values and arguments much more clear. 


### PR DESCRIPTION
Add documentation for difference in `this.args` vs `this` when passing parameters to glimmer components. 