### PR TITLE
Added Percy snapshot for es translations

### DIFF
--- a/tests/acceptance/homepage/es-test.js
+++ b/tests/acceptance/homepage/es-test.js
@@ -1,0 +1,26 @@
+import { visit } from '@ember/test-helpers';
+import percySnapshot from '@percy/ember';
+import { setupIntl } from 'ember-intl/test-support';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Acceptance | Homepage | es', function(hooks) {
+  setupApplicationTest(hooks);
+  setupIntl(hooks, 'es');
+
+
+  test('Percy snapshot', async function(assert) {
+    await visit('/');
+    await percySnapshot(assert);
+
+    assert.ok(true);
+  });
+
+
+  test('We set the correct lang attribute in <html> element', async function(assert) {
+    await visit('/');
+
+    assert.dom(document.querySelector('html'))
+      .hasAttribute('lang', 'es', 'We set the correct lang attribute.');
+  });
+});


### PR DESCRIPTION
## Description

Now that the translations for `es` are in place, let's add a Percy snapshot to avoid a possible regression in visuals or translations.