### PR TITLE
Upgraded percy/exec-action to v0.3.1

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,6 +1,6 @@
 name: CI/CD
 
-on: 
+on:
   push:
     branches:
       - master
@@ -93,20 +93,19 @@ jobs:
     needs: [lint, test-app]
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: success() && github.ref == 'refs/heads/master' && github.event_name == 'push'
+    # Only run on pushes to main branch that aren't from the cron workflow
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - name: Check out a copy of the repo
         uses: actions/checkout@v2
 
-      - name: Setup Git
+      - name: Set up Git user
         run: |
-          # Setup a Git user for committing
+          # Set up a Git user for committing
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@users.noreply.github.com"
 
-          # Copy the Git Auth from the local repository
-          # https://github.com/actions/checkout/blob/61b9e3751b92087fd0b06925ba6dd6314e06f089/src/git-auth-helper.ts#L69-L76
-          # https://github.com/actions/checkout/blob/61b9e3751b92087fd0b06925ba6dd6314e06f089/src/git-auth-helper.ts#L252-L278
+          # Copy the Git Auth from the local config
           git config --global "http.https://github.com/.extraheader" \
             "$(git config --local --get http.https://github.com/.extraheader)"
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -79,7 +79,7 @@ jobs:
         if: steps.cache-dependencies.outputs.cache-hit != 'true'
 
       - name: Test
-        uses: percy/exec-action@v0.3.0
+        uses: percy/exec-action@v0.3.1
         with:
           custom-command: yarn test
         env:


### PR DESCRIPTION
## Description

Recent CI runs produced a deprecation warning message:

```
The `set-env` command is deprecated and will be disabled on November 16th. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```

This results from the CI workflow using `v0.3.0` of `percy/exec-action`. Upgrading the action to `v0.3.1` should fix the issue.


## References

- https://github.com/percy/exec-action/releases/tag/v0.3.1