### PR TITLE
Fixed incorrect migration to @percy/cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
     "start": "ember serve",
-    "test": "percy exec -- ember test"
+    "test": "ember test"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",


### PR DESCRIPTION
## Description

In #98, I hadn't updated the `test` command in `package.json`. Because the `test` command had already included the words `percy exec`, Percy didn't run in CI when the pull request had been merged.

<img width="800" alt="Screenshot 2021-10-04 at 19 22 24" src="https://user-images.githubusercontent.com/16869656/135896031-060f0657-cbb5-4b2e-a108-f70779804737.png">
